### PR TITLE
Bump version to 3.1.0

### DIFF
--- a/scriptmerge/__init__.py
+++ b/scriptmerge/__init__.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from typing import Any, Callable, List
 import os
 
-__version__ = "3.0.1"
+__version__ = "3.1.0"
 
 
 from scriptmerge import merge_common as mc


### PR DESCRIPTION
This pull request includes a version update for the `scriptmerge` package. The most important change is the increment of the version number from `3.0.1` to `3.1.0` in the `__init__.py` file.

* [`scriptmerge/__init__.py`](diffhunk://#diff-abedcdce6ab5e54f64d42ab2545b99af8c57d76f79529d90a003f799f3a6a14eL5-R5): Updated the version number from `3.0.1` to `3.1.0`.